### PR TITLE
Revert some unicode character LatexCmds

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -373,11 +373,11 @@ var SummationNotation = P(MathCommand, function(_, super_) {
   };
 });
 
-LatexCmds['?'] =
+LatexCmds['∏'] =
 LatexCmds.sum =
 LatexCmds.summation = bind(SummationNotation,'\\sum ','&sum;');
 
-LatexCmds['?'] =
+LatexCmds['∑'] =
 LatexCmds.prod =
 LatexCmds.product = bind(SummationNotation,'\\prod ','&prod;');
 
@@ -455,7 +455,7 @@ CharCmds['/'] = P(Fraction, function(_, super_) {
 
 var SquareRoot =
 LatexCmds.sqrt =
-LatexCmds['v'] = P(MathCommand, function(_, super_) {
+LatexCmds['√'] = P(MathCommand, function(_, super_) {
   _.ctrlSeq = '\\sqrt';
   _.htmlTemplate =
       '<span class="mq-non-leaf">'


### PR DESCRIPTION
These changes slipped in at

https://github.com/sclower/mathquill/commit/f53cfb10caacbc1f9bf3b1d31f5589cabb78a199

I don't fully understand how this problem came about. @sclower
explained to me that there was an issue with an encoding
byte-order-mark that was preventing minification from running properly
(on windows), so he updated the file to not have that byte order mark.

Maybe things got garbled during that translation? It sounds like one of
our other contributors might have an editor configured in a way that is
adding a BOM that windows can't handle, but I'm not sure who/when that
happened. I'd love to have a better understanding of what's going on
here so that we don't run into this again.